### PR TITLE
Enable adding already instantiated view controller

### DIFF
--- a/Pod/Classes/RZMessagingWindow.h
+++ b/Pod/Classes/RZMessagingWindow.h
@@ -121,6 +121,12 @@ typedef void(^RZMessagingWindowAnimationCompletionBlock)(BOOL finished);
  */
 @property (assign, nonatomic) Class <RZMessagingViewController> messageViewControllerClass;
 
+/**
+ * Set this to assign an instance of ViewController that conforms to RZMessagingViewController.
+ * If such ViewController is set on the window it takes a precedence over a ViewController that
+ * would be created from the property messageViewControllerClass.
+ */
+@property (strong, nonatomic) UIViewController <RZMessagingViewController> *messageViewControllerInstance;
 
 /**
  *  The Message that is currently being displayed.

--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -224,7 +224,13 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
     if ( !self.errorPresented && !self.errorIsBeingPresented ) {
         self.errorIsBeingPresented = YES;
 
-        UIViewController <RZMessagingViewController> *messageVC = [[(Class)self.messageViewControllerClass alloc] init];
+        UIViewController <RZMessagingViewController> *messageVC = nil;
+        if ( self.messageViewControllerInstance ) {
+            messageVC = self.messageViewControllerInstance;
+        }
+        else {
+            messageVC = [[(Class)self.messageViewControllerClass alloc] init];            
+        }
 
         [self.rootViewController addChildViewController:messageVC];
         [self.rootViewController.view addSubview:messageVC.view];


### PR DESCRIPTION
*I like to expand capability of Raisin Toast by letting already instantiated view controller from the caller.  That way, instead of the view controller using default initializer, it can be configured to the will of the caller.
