### PR TITLE
Develop

### DIFF
--- a/Pod/Classes/RZErrorMessagingViewController.m
+++ b/Pod/Classes/RZErrorMessagingViewController.m
@@ -61,9 +61,6 @@ static CGFloat const kErrorMessagingViewVerticalPadding = 20.0f;
     return self;
 }
 
-/**
- *  Set the style of the status bar for the message
- */
 -(UIStatusBarStyle)preferredStatusBarStyle
 {
     return UIStatusBarStyleLightContent;

--- a/Pod/Classes/RZErrorMessagingViewController.m
+++ b/Pod/Classes/RZErrorMessagingViewController.m
@@ -61,6 +61,14 @@ static CGFloat const kErrorMessagingViewVerticalPadding = 20.0f;
     return self;
 }
 
+/**
+ *  Set the style of the status bar for the message
+ */
+-(UIStatusBarStyle)preferredStatusBarStyle
+{
+    return UIStatusBarStyleLightContent;
+}
+
 #pragma mark - UIViewController methods
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
@@ -162,6 +170,7 @@ static CGFloat const kErrorMessagingViewVerticalPadding = 20.0f;
         [UIView animateWithDuration:0.7f delay:0.0f usingSpringWithDamping:0.65f initialSpringVelocity:1.0f options:UIViewAnimationOptionCurveEaseInOut animations:^{
             [self.view.superview layoutIfNeeded];
             self.view.alpha = 1.0f;
+            [self setNeedsStatusBarAppearanceUpdate];
         } completion:^(BOOL finished) {
             if ( completion != nil ) {
                 completion(finished);
@@ -171,6 +180,7 @@ static CGFloat const kErrorMessagingViewVerticalPadding = 20.0f;
     else {
         [self.view.superview layoutIfNeeded];
         self.view.alpha = 1.0f;
+        [self setNeedsStatusBarAppearanceUpdate];
         if ( completion != nil ) {
             completion(YES);
         }
@@ -184,6 +194,7 @@ static CGFloat const kErrorMessagingViewVerticalPadding = 20.0f;
         [UIView animateWithDuration:0.7f delay:0.0f usingSpringWithDamping:0.65f initialSpringVelocity:1.0f options:UIViewAnimationOptionCurveEaseInOut animations:^{
             [self.view.superview layoutIfNeeded];
             self.view.alpha = 0.0f;
+            [self setNeedsStatusBarAppearanceUpdate];
         } completion:^(BOOL finished) {
             if ( completion != nil ) {
                 completion(finished);
@@ -193,6 +204,7 @@ static CGFloat const kErrorMessagingViewVerticalPadding = 20.0f;
     else {
         [self.view.superview layoutIfNeeded];
         self.view.alpha = 0.0f;
+        [self setNeedsStatusBarAppearanceUpdate];
         if ( completion != nil ) {
             completion(YES);
         }

--- a/Pod/Classes/RZMessagingWindow.h
+++ b/Pod/Classes/RZMessagingWindow.h
@@ -68,7 +68,7 @@ typedef void(^RZMessagingWindowAnimationCompletionBlock)(BOOL finished);
 #pragma mark - RZMessagingWindow
 
 /**
- *  Protocol to support if using a custom view controller for presenting errors
+ *  Protocol to support if using a custom view controller for presenting errors. If you provide preferredStatusBarStyle in your custom messaging view controller the error message will use the specified style when an error presents and can animate it in and out.
  */
 @protocol RZMessagingViewController <NSObject>
 /**
@@ -81,6 +81,8 @@ typedef void(^RZMessagingWindowAnimationCompletionBlock)(BOOL finished);
 /**
  *  Sets up the appearance of the error message and configures the height of the error window to match the message.
  *
+ *  Call [self setNeedsStatusBarAppearanceUpdate] inside this method to respect the preferredStatusBarStyle you provide in your messaging view controller
+ *
  *  @param animated   If error appearance is animated, responsible for providing the animation block and executing the completion block upon finishing.  Without animation, it simply presents the error and executes the completion block.
  *  @param completion Any code to execute once presented. For example you could not use autodismiss property (dismisses on tap) and have the completion handler start a timer and dismiss the error window upon expiration.
  */
@@ -88,6 +90,8 @@ typedef void(^RZMessagingWindowAnimationCompletionBlock)(BOOL finished);
 
 /**
  *  Sets up the constraints necessary to hide the error window and animate if desired.
+ *
+ *  Call [self setNeedsStatusBarAppearanceUpdate] inside this method to respect the preferredStatusBarStyle you provide in your messaging view controller
  *
  *  @param animated   If animated, will configure the view animation and execute the completion block if provided. If not, it just calls the completion block.
  *  @param completion Cleanup to do after an error is dismissed. For example you may want to pop out of a view controller or reload a network request.

--- a/Pod/Classes/RZMessagingWindow.h
+++ b/Pod/Classes/RZMessagingWindow.h
@@ -121,6 +121,12 @@ typedef void(^RZMessagingWindowAnimationCompletionBlock)(BOOL finished);
  */
 @property (assign, nonatomic) Class <RZMessagingViewController> messageViewControllerClass;
 
+/**
+ * Set this to assign an instance of ViewController that conforms to RZMessagingViewController.
+ * If such ViewController is set on the window it takes a precedence over a ViewController that
+ * would be created from the property messageViewControllerClass.
+ */
+@property (strong, nonatomic) UIViewController <RZMessagingViewController> *messageViewControllerInstance;
 
 /**
  *  The Message that is currently being displayed.

--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -302,7 +302,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
         statusBarStyle = [super preferredStatusBarStyle];
     }
     else {
-        statusBarStyle = topViewController.preferredStatusBarStyle;
+        statusBarStyle = [topViewController preferredStatusBarStyle];
     }
     return statusBarStyle;
 }
@@ -316,7 +316,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
         childViewController = [self.childViewControllers lastObject];
     }
     else {
-        childViewController = topViewController.childViewControllerForStatusBarStyle;
+        childViewController = [topViewController childViewControllerForStatusBarStyle];
     }
     return childViewController;
     
@@ -326,14 +326,14 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 {
     UIViewController *topViewController = [RZRootMessagingViewController topViewController];
     
-    return topViewController.shouldAutorotate;
+    return [topViewController shouldAutorotate];
 }
 
 - (NSUInteger)supportedInterfaceOrientations
 {
     UIViewController *topViewController = [RZRootMessagingViewController topViewController];
     
-    return topViewController.supportedInterfaceOrientations;;
+    return [topViewController supportedInterfaceOrientations];
 }
 
 #pragma mark - Helper class methods

--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -127,7 +127,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 
 - (NSError *)displayedError
 {
-    return [self.errorsToDisplay firstObject];
+    return [[self.errorsToDisplay firstObject] error];
 }
 
 - (BOOL)isCurrentlyDisplayingAnError

--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -224,7 +224,13 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
     if ( !self.errorPresented && !self.errorIsBeingPresented ) {
         self.errorIsBeingPresented = YES;
 
-        UIViewController <RZMessagingViewController> *messageVC = [[(Class)self.messageViewControllerClass alloc] init];
+        UIViewController <RZMessagingViewController> *messageVC = nil;
+        if ( self.messageViewControllerInstance ) {
+            messageVC = self.messageViewControllerInstance;
+        }
+        else {
+            messageVC = [[(Class)self.messageViewControllerClass alloc] init];            
+        }
 
         [self.rootViewController addChildViewController:messageVC];
         [self.rootViewController.view addSubview:messageVC.view];

--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -292,28 +292,48 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 
 #pragma mark - Orientation method overrides
 
+-(UIStatusBarStyle)preferredStatusBarStyle
+{
+    UIViewController *topViewController = [RZRootMessagingViewController topViewController];
+
+    UIStatusBarStyle statusBarStyle;
+    
+    if ( [(RZMessagingWindow *)self.view.window errorIsBeingPresented] ) {
+        statusBarStyle = [super preferredStatusBarStyle];
+    }
+    else {
+        statusBarStyle = topViewController.preferredStatusBarStyle;
+    }
+    return statusBarStyle;
+}
+
+-(UIViewController *)childViewControllerForStatusBarStyle
+{
+    UIViewController *topViewController = [RZRootMessagingViewController topViewController];
+    
+    UIViewController *childViewController;
+    if ( [(RZMessagingWindow *)self.view.window errorIsBeingPresented] ) {
+        childViewController = [self.childViewControllers lastObject];
+    }
+    else {
+        childViewController = topViewController.childViewControllerForStatusBarStyle;
+    }
+    return childViewController;
+    
+}
+
 -(BOOL)shouldAutorotate
 {
     UIViewController *topViewController = [RZRootMessagingViewController topViewController];
     
-    if ( topViewController == self ) {
-        return [super shouldAutorotate];
-    }
-    else {
-        return topViewController.shouldAutorotate;
-    }
+    return topViewController.shouldAutorotate;
 }
 
 - (NSUInteger)supportedInterfaceOrientations
 {
     UIViewController *topViewController = [RZRootMessagingViewController topViewController];
     
-    if ( topViewController == self ) {        
-        return [super supportedInterfaceOrientations];
-    }
-    else {
-        return topViewController.supportedInterfaceOrientations;
-    }
+    return topViewController.supportedInterfaceOrientations;;
 }
 
 #pragma mark - Helper class methods
@@ -325,10 +345,9 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
  */
 + (UIViewController *)topViewController
 {
-    NSArray *windows = [UIApplication sharedApplication].windows;
-    UIWindow *firstWindow = [windows firstObject];
+    UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
     
-    return [RZRootMessagingViewController topViewControllerWithRootViewController:firstWindow.rootViewController];
+    return [RZRootMessagingViewController topViewControllerWithRootViewController:keyWindow.rootViewController];
 }
 
 /**


### PR DESCRIPTION
- Status bar color now respects underlying window but with ability to override for display of toast (thanks @jvisenti )
- Now correctly returns the NSError object (thanks @sixstringtheory )
- Adds the ability to provide an instantiated VC instead of alloc init one of the specified class. This allows VC reuse but more importantly allows you to use an initializer other than the basic init.  The use case for this is being able to create a relationship between the toast and the underlying view controller that triggered presentation. (thanks @rztakashi )
