### PR TITLE
Fix conflicting interface orientation return type

### DIFF
--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -335,7 +335,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
     return [topViewController shouldAutorotate];
 }
 
-- (NSUInteger)supportedInterfaceOrientations
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
     UIViewController *topViewController = [RZRootMessagingViewController topViewController];
     

--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -335,7 +335,11 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
     return [topViewController shouldAutorotate];
 }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
+#else
+- (NSUInteger)supportedInterfaceOrientations
+#endif
 {
     UIViewController *topViewController = [RZRootMessagingViewController topViewController];
     


### PR DESCRIPTION
This changes the`RZMessagingWindow` `supportedInterfaceOrientations` return type from `NSUInteger` to `UIInterfaceOrientationMask` to silence compiler warnings about conflicting types.
