### PR TITLE
hideMessage: does not function correctly when bridged into Swift.

### DIFF
--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -31,6 +31,10 @@
 
 static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 
+@interface UIApplication (mainWindow)
+- (UIWindow*)mainApplicationWindowIgnoringWindow:(UIWindow*)ignoringWindow;
+@end
+
 /**
  *  This is used to identify what touches need to be passed through to the main application window.
  */
@@ -322,7 +326,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 
 -(UIStatusBarStyle)preferredStatusBarStyle
 {
-    UIViewController *topViewController = [RZRootMessagingViewController topViewController];
+    UIViewController *topViewController = [self topViewController];
 
     UIStatusBarStyle statusBarStyle;
     
@@ -337,7 +341,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 
 -(UIViewController *)childViewControllerForStatusBarStyle
 {
-    UIViewController *topViewController = [RZRootMessagingViewController topViewController];
+    UIViewController *topViewController = [self topViewController];
     
     UIViewController *childViewController;
     if ( [(RZMessagingWindow *)self.view.window errorIsBeingPresented] ) {
@@ -352,14 +356,14 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 
 -(BOOL)shouldAutorotate
 {
-    UIViewController *topViewController = [RZRootMessagingViewController topViewController];
+    UIViewController *topViewController = [self topViewController];
     
     return [topViewController shouldAutorotate];
 }
 
 - (NSUInteger)supportedInterfaceOrientations
 {
-    UIViewController *topViewController = [RZRootMessagingViewController topViewController];
+    UIViewController *topViewController = [self topViewController];
     
     return [topViewController supportedInterfaceOrientations];
 }
@@ -371,11 +375,12 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
  *
  * @return Returns the visible, presented view controller.
  */
-+ (UIViewController *)topViewController
+- (UIViewController *)topViewController
 {
-    UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
+    // UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
+    UIWindow *mainAppWindow = [[UIApplication sharedApplication] mainApplicationWindowIgnoringWindow:self.view.window];
     
-    return [RZRootMessagingViewController topViewControllerWithRootViewController:keyWindow.rootViewController];
+    return [RZRootMessagingViewController topViewControllerWithRootViewController:mainAppWindow.rootViewController];
 }
 
 /**
@@ -402,3 +407,16 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 }
 
 @end
+
+@implementation UIApplication (mainWindow)
+// we don't want the keyWindow, since it could be our own window
+- (UIWindow*)mainApplicationWindowIgnoringWindow:(UIWindow *)ignoringWindow {
+    for (UIWindow *window in [[UIApplication sharedApplication] windows]) {
+        if (!window.hidden && window != ignoringWindow) {
+            return window;
+        }
+    }
+    return nil;
+}
+@end
+

--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -211,7 +211,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
         
         switch (foundAt) {
             case 0:
-                [self hideDisplayedErrorAnimated:animated force:NO];
+                [self hideDisplayedErrorAnimated:animated force:YES];
                 break;
             case -1:
                 break;

--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -191,11 +191,33 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
         [self hideDisplayedErrorAnimated:animated force:NO];
     }
     else {
-        NSInteger index = [self.errorsToDisplay indexOfObject:error];
-        if ( index == 1 ) {
-            [self hideDisplayedErrorAnimated:animated force:NO];
-        } else {
-            [self.errorsToDisplay removeObject:error];
+        // We can't use indexOfObject and removeObject here
+        // when bridged to Swift since the array contains
+        // RZMessage objects and we have an NSError object.
+        // Objective-C will still iterate of the array and
+        // call isEqual on all the members, Swift will not.
+        // More than likely it may be necessary to start
+        // returning RZMessage objects as handles rather
+        // than NSError?
+        NSInteger index = 0;
+        NSInteger foundAt = -1;
+        for (RZMessage *msg in self.errorsToDisplay) {
+            if ([error isEqual:msg.error]) {
+                foundAt = index;
+                break;
+            }
+            index++;
+        }
+        
+        switch (foundAt) {
+            case 0:
+                [self hideDisplayedErrorAnimated:animated force:NO];
+                break;
+            case -1:
+                break;
+            default:
+                [self.errorsToDisplay removeObjectAtIndex:foundAt];
+                break;
         }
     }
 }


### PR DESCRIPTION
Explicitly loop through the errorsToDisplay array in hideMessage: and look for the index of the 
record we need instead of using indexOf and removeObject.  Swift will not call the equality operators since we have RZMessage objects in the array and NSError objects to compare.
