### PR TITLE
v1.0.5 Fixed warnings and sample project crash, simplified docs

### DIFF
--- a/Example/RaisinToast.xcodeproj/project.pbxproj
+++ b/Example/RaisinToast.xcodeproj/project.pbxproj
@@ -189,7 +189,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = RZ;
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = adamhrz;
 			};
 			buildConfigurationList = 6003F585195388D10070C39A /* Build configuration list for PBXProject "RaisinToast" */;
@@ -312,6 +312,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -375,6 +376,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RaisinToast/RaisinToast-Prefix.pch";
 				INFOPLIST_FILE = "RaisinToast/RaisinToast-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
@@ -390,6 +392,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RaisinToast/RaisinToast-Prefix.pch";
 				INFOPLIST_FILE = "RaisinToast/RaisinToast-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;

--- a/Example/RaisinToast.xcodeproj/xcshareddata/xcschemes/RaisinToast-Example.xcscheme
+++ b/Example/RaisinToast.xcodeproj/xcshareddata/xcschemes/RaisinToast-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,17 +48,21 @@
             ReferencedContainer = "container:RaisinToast.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6003F589195388D20070C39A"
@@ -71,12 +75,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6003F589195388D20070C39A"

--- a/Example/RaisinToast/RZTCustomErrorViewController.m
+++ b/Example/RaisinToast/RZTCustomErrorViewController.m
@@ -10,7 +10,7 @@
 
 @interface RZTCustomErrorViewController ()
 @property (weak, nonatomic) NSError *error;
-@property (strong, nonatomic) UIAlertView *alertView;
+@property (strong, nonatomic) UIAlertController *alertViewController;
 @property (weak, nonatomic) NSLayoutConstraint *bottomAnimationConstraint;
 @property (weak, nonatomic) NSLayoutConstraint *heightConstraint;
 @end
@@ -31,13 +31,17 @@
 - (void)rz_configureWithError:(NSError *)error
 {
     self.error = error;
-    self.alertView = [[UIAlertView alloc] initWithTitle:self.error.localizedDescription message:self.error.localizedRecoverySuggestion delegate:self cancelButtonTitle:@"OK" otherButtonTitles:nil];
+    self.alertViewController = [UIAlertController alertControllerWithTitle:self.error.localizedDescription message:self.error.localizedRecoverySuggestion preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction* defaultAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+    
+    [self.alertViewController addAction:defaultAction];
 }
 
 - (void)rz_presentAnimated:(BOOL)animated completion:(RZMessagingWindowAnimationCompletionBlock)completion
 {
     self.view.hidden = NO;
-    [self.alertView show];
+    [self presentViewController:self.alertViewController animated:YES completion:nil];
 
     if ( completion != nil ) {
         completion(YES);
@@ -46,7 +50,8 @@
 
 - (void)rz_dismissAnimated:(BOOL)animated completion:(RZMessagingWindowAnimationCompletionBlock)completion
 {
-    [self.alertView dismissWithClickedButtonIndex:self.alertView.cancelButtonIndex animated:animated];
+    [self dismissViewControllerAnimated:animated completion:nil];
+
     self.bottomAnimationConstraint.constant = 0.0f;
     self.view.alpha = 0.0f;
     self.view.hidden = YES;

--- a/Example/RaisinToast/RaisinToast-Info.plist
+++ b/Example/RaisinToast/RaisinToast-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Pod/Classes/RZErrorMessagingViewController.m
+++ b/Pod/Classes/RZErrorMessagingViewController.m
@@ -232,15 +232,16 @@ static CGFloat const kErrorMessagingViewVerticalPadding = 20.0f;
 - (CGFloat)updatedHeightWithWidth:(CGFloat)width
 {
     CGFloat height = _errorMessagingViewVisibleHeight;
-    
-    NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:self.detailLabel.text attributes:@{ NSFontAttributeName : self.detailLabel.font }];
-    CGRect rect = [attributedText boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX)
-                                               options:NSStringDrawingUsesLineFragmentOrigin
-                                               context:nil];
-    
-    CGSize size = rect.size;
-    
-    height += size.height;
+
+    if ( self.detailLabel.text != nil ) {
+        NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:self.detailLabel.text attributes:@{ NSFontAttributeName : self.detailLabel.font }];
+        CGRect rect = [attributedText boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX)
+                                                   options:NSStringDrawingUsesLineFragmentOrigin
+                                                   context:nil];
+
+        height += CGRectGetHeight(rect);
+    }
+
     return height;
 }
 

--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -370,7 +370,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
         UINavigationController* navigationController = (UINavigationController *)rootViewController;
         return [RZRootMessagingViewController topViewControllerWithRootViewController:navigationController.visibleViewController];
     }
-    else if ( rootViewController.presentedViewController ) {
+    else if ( rootViewController.presentedViewController && !rootViewController.presentedViewController.isBeingDismissed ) {
         UIViewController* presentedViewController = rootViewController.presentedViewController;
         return [RZRootMessagingViewController topViewControllerWithRootViewController:presentedViewController];
     }

--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -57,7 +57,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 
 + (instancetype)messageFromError:(NSError *)error animated:(BOOL)animated messageStrength:(RZMessageStrength)strength
 {
-    RZMessage *message = [[RZMessage alloc] init];
+    RZMessage *message = [[self alloc] init];
     message.error = error;
     message.animated = animated;
     message.strength = strength;
@@ -93,7 +93,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 
 + (instancetype)messagingWindow
 {
-    RZMessagingWindow *messageWindow = [[RZMessagingWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+    RZMessagingWindow *messageWindow = [[self alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     RZRootMessagingViewController *rootVC = [[RZRootMessagingViewController alloc] init];
     messageWindow.rootViewController = rootVC;
     //Automatically adds itself
@@ -103,7 +103,7 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 
 + (instancetype)defaultMessagingWindow
 {
-    RZMessagingWindow *messageWindow = [RZMessagingWindow messagingWindow];
+    RZMessagingWindow *messageWindow = [self messagingWindow];
     messageWindow.messageViewControllerClass = [RZErrorMessagingViewController class];
     return messageWindow;
 }

--- a/README.md
+++ b/README.md
@@ -43,29 +43,20 @@ If you do not have CocoaPods installed, follow the instructions [here](http://co
 ## Basic Overview
 ### Configuration
 
-In app delegate add to imports:
+In app delegate implementation import RZMessagingWindow:
 
 ```objc
-@class RZMessagingWindow;
-```
-
-Add new property:
-
-```objc
-@property (strong, nonatomic) RZMessagingWindow *errorWindow;
+#import "RZMessagingWindow.h";
 ```
 
 In implementation add the setup code to `applicationDidBecomeActive:` and it must come *AFTER* the `[self.window makeKeyAndVisible]` :
 
-
 ```objc
 -(void)applicationDidBecomeActive:(UIApplication *)application
 {
-    [self.window makeKeyAndVisible];
-    if ( self.errorWindow == nil ) {
-        self.errorWindow = [RZMessagingWindow defaultMessagingWindow];
-        [RZErrorMessenger setDefaultMessagingWindow:self.errorWindow];
-    }
+    [self.window makeKeyAndVisible]; // Must come first
+
+    [RZErrorMessenger setDefaultMessagingWindow:[RZMessagingWindow defaultMessagingWindow]];
 }
 ```
 
@@ -124,6 +115,37 @@ Next we present the error and provide the message strength with displayError:wit
 You could, though we advise against it, use Raisin Toast to present standard NSError objects. This might be helpful during debugging but typically you wouldn't want to show the user any of the system generated errors because they're intended for devs.
 
 ## Advanced Options
+### Customizing the error window
+
+If you plan on supporting multiple error window styles or customizing you'll need to configure your app delegate a different way:
+
+In app delegate add to imports:
+
+```objc
+@class RZMessagingWindow;
+```
+
+Add a new property to the app delegate:
+
+```objc
+@property (strong, nonatomic) RZMessagingWindow *errorWindow;
+```
+
+In your delegate implementation add the setup code to `applicationDidBecomeActive:` and it must come *AFTER* the `[self.window makeKeyAndVisible]` :
+
+
+```objc
+-(void)applicationDidBecomeActive:(UIApplication *)application
+{
+    [self.window makeKeyAndVisible]; // Must come first
+
+    if ( self.errorWindow == nil ) {
+        self.errorWindow = [RZMessagingWindow defaultMessagingWindow];
+        [RZErrorMessenger setDefaultMessagingWindow:self.errorWindow];
+    }
+}
+```
+
 ### Style override
 
 Subclass RZErrorMessagingViewController 

--- a/RaisinToast.podspec
+++ b/RaisinToast.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "RaisinToast"
-  s.version          = "1.0.4"
+  s.version          = "1.0.5"
   s.summary          = "A UIWindow subclass used to message information to the users of your app."
   s.description      = <<-DESC
 RaisinToast provides a messaging window layer and a default "toast" view controller, ideal for presenting errors, warnings and feedback throughout your app. Think of it as bringing the really useful messaging concept of Android Toast to iOS.


### PR DESCRIPTION
- Adds a check to ignore windows that are currently being dismissed from status bar color forwarding
- Nil checks alert description when calculating height of alerts
- Fixed sample app crash due to UIAlertView usage
- Conditional SDK check to eliminate return type warning
- Updated readme to illustrate simpler quick setup steps

thanks to @ateliercw @adolfo @zeveisenberg
