### PR TITLE
Fix crash when keyboard tries to display an alert

### DIFF
--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -349,15 +349,15 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 #pragma mark - Helper class methods
 
 /**
- * Find the presented top view controller of the keyed UIWindow's root view controller.
+ * Find the presented top view controller of the App Delegate UIWindow's root view controller.
  *
  * @return Returns the visible, presented view controller.
  */
 + (UIViewController *)topViewController
 {
-    UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
+    UIWindow *mainWindow = [UIApplication sharedApplication].delegate.window;
     
-    return [RZRootMessagingViewController topViewControllerWithRootViewController:keyWindow.rootViewController];
+    return [RZRootMessagingViewController topViewControllerWithRootViewController:mainWindow.rootViewController];
 }
 
 /**


### PR DESCRIPTION
Demo project with crash here: https://www.dropbox.com/s/jqaaw9zb23ly4ew/RaisinToastKeyboardCrash.zip?dl=0

Repro steps:
1. Reset content and settings of the simulator
2. Run demo app
3. Tap on the text field
4. Show the software keyboard in the simulator (cmd + k)
5. Tap the smiley button to bring up the emoji keyboard
6. Tap the "ABC" button to bring back the regular keyboard

The keyboard will attempt to display an alert to inform the user about alternate keyboards:
![screen shot 2015-10-28 at 10 56 51 am](https://cloud.githubusercontent.com/assets/721387/10798010/a3c1b3a2-7d62-11e5-973c-31ecc84f5c2d.png)

Instead, the app will crash on an infinite loop in 
`- (UIInterfaceOrientationMask)supportedInterfaceOrientations` because `[UIApplication sharedApplication].keyWindow` accessed in `+ (UIViewController *)topViewController` is no longer the main app window. 

The way I've addressed this is to use the app delegate's window instead of the key window, which in my testing are always the same value _except_ for when the aforementioned alert is being displayed. 

**Caution: Not having written this library, I am concerned that there might be further implications of this change.**
