### PR TITLE
Do not show a duplicate error for the currently displayed error.

### DIFF
--- a/Pod/Classes/RZMessagingWindow.m
+++ b/Pod/Classes/RZMessagingWindow.m
@@ -178,7 +178,10 @@ static CGFloat const RZErrorWindowBlackoutAnimationInterval = 0.5f;
 - (void)showMessageFromError:(NSError *)error strength:(RZMessageStrength)strength animated:(BOOL)animated
 {
     NSParameterAssert(error);
-    
+    if ([error isEqual:self.displayedError]) {
+        return;
+    }
+
     RZMessage *message = [RZMessage messageFromError:error animated:animated messageStrength:strength];
     [self showMessage:message];
     [self.errorsToDisplay addObject:message];


### PR DESCRIPTION
Currently, showing multiple duplicate errors in a row will show the first, and then add the rest to the `errorsToDisplay` queue. As a result, the same error dismisses just to reveal many duplicates.

There are a few potential solutions.
1. Don't show error if error is already in `errorsToDisplay`
2. If error is already in `errorsToDisplay` move it to the front of the list.
3. Don't show error if error is currently being shown.

This PR is for option 3, but we can discuss the other options.
